### PR TITLE
Changedrolls to be a generator, adapted tests

### DIFF
--- a/tabletoprandom/abstract/primitives.py
+++ b/tabletoprandom/abstract/primitives.py
@@ -46,7 +46,7 @@ class Rollable(Iterable[T], abc.ABC):
         """
         while n > 0:
             n -= 1
-            yield(next(self))
+            yield self.roll()
 
     def __iter__(self) -> T:
         return self

--- a/tabletoprandom/abstract/primitives.py
+++ b/tabletoprandom/abstract/primitives.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 import abc
-from typing import List, Iterable, TypeVar
+from typing import Iterable, TypeVar
 
 T = TypeVar('T')
 
@@ -31,8 +31,8 @@ class Rollable(Iterable[T], abc.ABC):
         self.last_roll = self.__roll__()
         return self.last_roll
 
-    def rolls(self, n: int) -> List[T]:
-        """Returns a list of values equivalent to calling `roll` `n` times
+    def rolls(self, n: int) -> Iterable[T]:
+        """A generator equivalent to calling `roll` `n` times
 
         Parameters
         ----------
@@ -41,12 +41,12 @@ class Rollable(Iterable[T], abc.ABC):
 
         Returns
         -------
-        List[T]
-            A list of results from roll
+        Iterable[T]
+            A generator of results from roll
         """
-        if n < 0:
-            raise ValueError("Cannot request a negative number of rolls")
-        return list(next(self) for _ in range(n))
+        while n > 0:
+            n -= 1
+            yield(next(self))
 
     def __iter__(self) -> T:
         return self

--- a/tests/test_dice/test_magicaldie.py
+++ b/tests/test_dice/test_magicaldie.py
@@ -114,26 +114,17 @@ class MagicalDie_TestCase(unittest.TestCase):
                 self.assertListEqual(
                     *self.seq_seed_capture_repeat_capture(i, self.d20, 3*i)
                 )
-        self.assertListEqual(self.d3.rolls(0), [])
-        self.assertListEqual(self.d6.rolls(0), [])
-        self.assertListEqual(self.d20.rolls(0), [])
-        with self.assertRaises(ValueError):
-            self.d3.rolls(-1)
-        with self.assertRaises(ValueError):
-            self.d6.rolls(-1)
-        with self.assertRaises(ValueError):
-            self.d20.rolls(-1)
-        with self.assertRaises(ValueError):
-            self.d3.rolls(-1000)
-        with self.assertRaises(ValueError):
-            self.d6.rolls(-1000)
-        with self.assertRaises(ValueError):
-            self.d20.rolls(-1000)
+        with self.assertRaises(StopIteration):
+            next(self.d3.rolls(0))
+        with self.assertRaises(StopIteration):
+            next(self.d3.rolls(-1))
+        with self.assertRaises(StopIteration):
+            next(self.d3.rolls(-1000))
 
     def seq_seed_capture_repeat_capture(self, seed, die, n):
         repeat_captures = []
         random.seed(seed)
-        die_captures = die.rolls(n)
+        die_captures = list(die.rolls(n))
         random.seed(seed)
         for i in range(n):
             repeat_captures.append(random.choice(tuple(die.faces)))

--- a/tests/test_dice/test_traditionaldie.py
+++ b/tests/test_dice/test_traditionaldie.py
@@ -114,26 +114,17 @@ class TraditionalDie_TestCase(unittest.TestCase):
                 self.assertListEqual(
                     *self.seq_seed_capture_repeat_capture(i, self.d20, 3*i)
                 )
-        self.assertListEqual(self.d3.rolls(0), [])
-        self.assertListEqual(self.d6.rolls(0), [])
-        self.assertListEqual(self.d20.rolls(0), [])
-        with self.assertRaises(ValueError):
-            self.d3.rolls(-1)
-        with self.assertRaises(ValueError):
-            self.d6.rolls(-1)
-        with self.assertRaises(ValueError):
-            self.d20.rolls(-1)
-        with self.assertRaises(ValueError):
-            self.d3.rolls(-1000)
-        with self.assertRaises(ValueError):
-            self.d6.rolls(-1000)
-        with self.assertRaises(ValueError):
-            self.d20.rolls(-1000)
+        with self.assertRaises(StopIteration):
+            next(self.d3.rolls(0))
+        with self.assertRaises(StopIteration):
+            next(self.d3.rolls(-1))
+        with self.assertRaises(StopIteration):
+            next(self.d3.rolls(-1000))
 
     def seq_seed_capture_repeat_capture(self, seed, die, n):
         repeat_captures = []
         random.seed(seed)
-        die_captures = die.rolls(n)
+        die_captures = list(die.rolls(n))
         random.seed(seed)
         for i in range(n):
             repeat_captures.append(random.choice(tuple(die.faces)))


### PR DESCRIPTION
This adapted the rolls function to be a generator rather than returning a list, this can better amortize the work on large sets of rolls, useful for the upcoming composite rolls. 